### PR TITLE
feat: migrate to @myparcel-dev scope

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,40 @@
-name: 'Publish new release 🚀'
+name: Release
 
 on:
   push:
     branches:
       - main
-    paths:
-      - index.js
-      - package.json
-      - yarn.lock
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  process:
-    runs-on: ubuntu-20.04
+  release:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: myparcelnl/actions/yarn-install@v1
-      - name: 'Release'
-        run: npx semantic-release
+      - name: Setup Git credentials
+        id: credentials
+        uses: myparcelnl/actions/setup-git-credentials@v4
+        with:
+          app-id: ${{ secrets.MYPARCEL_APP_ID }}
+          private-key: ${{ secrets.MYPARCEL_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.credentials.outputs.token }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.credentials.outputs.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_NEW }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_NEW }}
+        run: npx semantic-release

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# @myparcel/prettier-config
+# @myparcel-dev/prettier-config
 
-[![NPM version](https://img.shields.io/npm/v/@myparcel/prettier-config)](https://www.npmjs.com/package/@myparcel/prettier-config/)
+[![NPM version](https://img.shields.io/npm/v/@myparcel-dev/prettier-config)](https://www.npmjs.com/package/@myparcel-dev/prettier-config/)
 
 ## Installation
 
 Using Yarn:
 
 ```shell
-yarn add -D @myparcel/prettier-config
+yarn add -D @myparcel-dev/prettier-config
 ```
 
 Using NPM:
 
 ```shell
-npm i -D @myparcel/prettier-config
+npm i -D @myparcel-dev/prettier-config
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ Add this to your `package.json`:
 
 ```json
 {
-  "prettier": "@myparcel/prettier-config"
+  "prettier": "@myparcel-dev/prettier-config"
 }
 ```
 
@@ -32,7 +32,7 @@ And you're good to go! There are a few more specific configurations below.
 
 ```json
 {
-  "prettier": "@myparcel/prettier-config/es5"
+  "prettier": "@myparcel-dev/prettier-config/es5"
 }
 ```
 
@@ -47,7 +47,7 @@ And you're good to go! There are a few more specific configurations below.
 
 ```json
 {
-  "prettier": "@myparcel/prettier-config/vue"
+  "prettier": "@myparcel-dev/prettier-config/vue"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@myparcel/prettier-config",
-  "version": "1.1.0",
+  "name": "@myparcel-dev/prettier-config",
+  "version": "2.0.0",
   "description": "Prettier configuration for MyParcel",
   "main": "index.js",
   "publishConfig": {
@@ -14,9 +14,9 @@
   "author": "edie@myparcel.nl",
   "license": "ISC",
   "devDependencies": {
-    "@myparcel/semantic-release-config": "^3.1.0"
+    "@myparcel-dev/semantic-release-config": "^6.0.0"
   },
   "release": {
-    "extends": "@myparcel/semantic-release-config/github-npm"
+    "extends": "@myparcel-dev/semantic-release-config/github-npm"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Package name changed from @myparcel/prettier-config to @myparcel-dev/prettier-config

- Updated package name and version to 2.0.0
- Updated semantic-release-config dependency to new scope
- Updated README with new package name
- Updated GitHub Actions workflow